### PR TITLE
Updated email configuration for sendgrid custom domain

### DIFF
--- a/cybersecurity_assessment_tool/api/views.py
+++ b/cybersecurity_assessment_tool/api/views.py
@@ -270,7 +270,8 @@ def public_registration(request):
                 # replace it with your own and replace the database user to have the emails sent to your email)
                 system_user = User.objects.create_user(
                     username="Frontend Integration Testing",
-                    email=settings.DEFAULT_FROM_EMAIL,
+                    email_inbox=settings.ADMIN_EMAIL_INBOX,
+					email=settings.DEFAULT_FROM_EMAIL,
                     password=settings.EMAIL_HOST_PASSWORD,
                     first_name="System",
                     last_name="Integration",
@@ -316,7 +317,7 @@ def public_registration(request):
             print(f"Generated reject URL: {reject_url}")
             
             # Send request email to admin
-            queue_email('request', system_user.email, {
+            queue_email('request', system_user.email_inbox, {
                 'requester_name': f"{user.first_name} {user.last_name}",
                 "requester_email": user.email,
                 "company": user.organization.org_name if user.organization else "Unknown",

--- a/cybersecurity_assessment_tool/config/settings.py
+++ b/cybersecurity_assessment_tool/config/settings.py
@@ -255,6 +255,7 @@ EMAIL_BACKEND_TYPE = os.environ.get('EMAIL_BACKEND_TYPE', 'console')
 
 # Determine if we're on Heroku
 IS_HEROKU = 'DYNO' in os.environ or 'HEROKU' in os.environ
+ADMIN_EMAIL_INBOX = os.environ.get('ADMIN_EMAIL_INBOX')
 
 if EMAIL_BACKEND_TYPE == 'sendgrid' or IS_HEROKU:
     # Use SendGrid on Heroku


### PR DESCRIPTION
As we switch to using sendgrid with a custom domain for sending emails to users, our current system of sending emails to the same location as the address that we send from no longer works. This is because sendgrid does just that: *send*. It does not act as an inbox where we can *receive*, so we still need to keep our gmail address as the recipient for org request emails. 