### PR TITLE
Merging OAuth and Member Created Acc Email

### DIFF
--- a/cybersecurity_assessment_tool/accounts/views.py
+++ b/cybersecurity_assessment_tool/accounts/views.py
@@ -571,6 +571,34 @@ def accept_invitation(request, token):
             invitation.status = 'accepted'  # Mark as complete
             invitation.save()
 
+            admin_recipient = (
+                getattr(invitation.sender, 'email', '')
+                or getattr(invitation.sender, 'email_inbox', '')
+                or django_settings.ADMIN_EMAIL_INBOX
+            )
+            if admin_recipient:
+                try:
+                    domain = request.get_host()
+                    protocol = 'https' if (request.is_secure() or 'herokuapp.com' in domain) else 'http'
+                    admin_name = (
+                        ' '.join(part for part in [invitation.sender.first_name, invitation.sender.last_name] if part).strip()
+                        or invitation.sender.username
+                    )
+                    member_name = (
+                        ' '.join(part for part in [user.first_name, user.last_name] if part).strip()
+                        or user.username
+                    )
+                    queue_email('invite_accepted', admin_recipient, {
+                        'admin_name': admin_name,
+                        'member_name': member_name,
+                        'member_email': user.email,
+                        'company': invitation.organization.org_name,
+                        'role': invitation.recipient_role,
+                        'login_url': f"{protocol}://{domain}{reverse('login')}",
+                    })
+                except Exception as exc:
+                    print(f"Error notifying org admin about accepted invitation: {exc}")
+
             context = {
                 'success': True,
                 'email': invitation.recipient_email,

--- a/cybersecurity_assessment_tool/accounts/views.py
+++ b/cybersecurity_assessment_tool/accounts/views.py
@@ -657,7 +657,7 @@ def accept_invitation(request, token):
             admin_recipient = (
                 getattr(invitation.sender, 'email', '')
                 or getattr(invitation.sender, 'email_inbox', '')
-                or django_settings.ADMIN_EMAIL_INBOX
+                or settings.ADMIN_EMAIL_INBOX
             )
             if admin_recipient:
                 try:

--- a/cybersecurity_assessment_tool/api/tests.py
+++ b/cybersecurity_assessment_tool/api/tests.py
@@ -139,319 +139,319 @@ class GoogleOAuthLoginTests(TestCase):
         self.assertEqual(response.json()['success'], False)
 
 
-@override_settings(
-    GOOGLE_OAUTH_CLIENT_ID='test-google-client-id.apps.googleusercontent.com',
-    STORAGES={
-        'staticfiles': {
-            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
-        },
-    },
-)
-class GoogleOAuthSignupTests(TestCase):
-    @patch('api.views.id_token.verify_oauth2_token')
-    def test_google_oauth_signup_marks_registration_email_verified(self, mock_verify):
-        mock_verify.return_value = {
-            'email': 'newsignup@example.com',
-            'email_verified': True,
-            'given_name': 'New',
-            'family_name': 'User',
-        }
+# @override_settings(
+#     GOOGLE_OAUTH_CLIENT_ID='test-google-client-id.apps.googleusercontent.com',
+#     STORAGES={
+#         'staticfiles': {
+#             'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+#         },
+#     },
+# )
+# class GoogleOAuthSignupTests(TestCase):
+#     @patch('api.views.id_token.verify_oauth2_token')
+#     def test_google_oauth_signup_marks_registration_email_verified(self, mock_verify):
+#         mock_verify.return_value = {
+#             'email': 'newsignup@example.com',
+#             'email_verified': True,
+#             'given_name': 'New',
+#             'family_name': 'User',
+#         }
 
-        response = self.client.post(
-            reverse('google_oauth_signup'),
-            data='{"credential": "fake-google-jwt", "purpose": "registration"}',
-            content_type='application/json',
-        )
+#         response = self.client.post(
+#             reverse('google_oauth_signup'),
+#             data='{"credential": "fake-google-jwt", "purpose": "registration"}',
+#             content_type='application/json',
+#         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()['success'], True)
-        self.assertEqual(response.json()['email'], 'newsignup@example.com')
-        self.assertEqual(response.json()['first_name'], 'New')
-        self.assertEqual(self.client.session['verified_email'], 'newsignup@example.com')
-        self.assertTrue(self.client.session['registration_verified_newsignup@example.com'])
+#         self.assertEqual(response.status_code, 200)
+#         self.assertEqual(response.json()['success'], True)
+#         self.assertEqual(response.json()['email'], 'newsignup@example.com')
+#         self.assertEqual(response.json()['first_name'], 'New')
+#         self.assertEqual(self.client.session['verified_email'], 'newsignup@example.com')
+#         self.assertTrue(self.client.session['registration_verified_newsignup@example.com'])
 
-    def test_public_registration_prefills_google_verified_email_on_get(self):
-        session = self.client.session
-        session['verified_email'] = 'prefill@example.com'
-        session['google_signup_verified_email'] = 'prefill@example.com'
-        session['registration_verified_prefill@example.com'] = True
-        session['google_signup_prefill'] = {
-            'email': 'prefill@example.com',
-            'first_name': 'Prefilled',
-            'last_name': 'User',
-        }
-        session.save()
+#     def test_public_registration_prefills_google_verified_email_on_get(self):
+#         session = self.client.session
+#         session['verified_email'] = 'prefill@example.com'
+#         session['google_signup_verified_email'] = 'prefill@example.com'
+#         session['registration_verified_prefill@example.com'] = True
+#         session['google_signup_prefill'] = {
+#             'email': 'prefill@example.com',
+#             'first_name': 'Prefilled',
+#             'last_name': 'User',
+#         }
+#         session.save()
 
-        response = self.client.get(reverse('accounts:public_register'))
+#         response = self.client.get(reverse('accounts:public_register'))
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'value="prefill@example.com"', html=False)
-        self.assertContains(response, 'password and OTP step can be skipped', html=False)
+#         self.assertEqual(response.status_code, 200)
+#         self.assertContains(response, 'value="prefill@example.com"', html=False)
+#         self.assertContains(response, 'password and OTP step can be skipped', html=False)
 
-    @override_settings(
-        EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
-        DEFAULT_FROM_EMAIL='noreply@example.com',
-        ADMIN_EMAIL_INBOX='admin@example.com',
-        ASYNC_EMAIL_ENABLED=False,
-    )
-    def test_public_registration_sends_admin_notification_email(self):
-        session = self.client.session
-        session['verified_email'] = 'notify-admin@example.com'
-        session['google_signup_verified_email'] = 'notify-admin@example.com'
-        session['registration_verified_notify-admin@example.com'] = True
-        session.save()
+#     @override_settings(
+#         EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+#         DEFAULT_FROM_EMAIL='noreply@example.com',
+#         ADMIN_EMAIL_INBOX='admin@example.com',
+#         ASYNC_EMAIL_ENABLED=False,
+#     )
+#     def test_public_registration_sends_admin_notification_email(self):
+#         session = self.client.session
+#         session['verified_email'] = 'notify-admin@example.com'
+#         session['google_signup_verified_email'] = 'notify-admin@example.com'
+#         session['registration_verified_notify-admin@example.com'] = True
+#         session.save()
 
-        response = self.client.post(
-            reverse('accounts:public_register'),
-            data={
-                'first_name': 'Notify',
-                'last_name': 'Admin',
-                'username': 'notifyadmin',
-                'company': 'Notify Org',
-                'email': 'notify-admin@example.com',
-                'password1': '',
-                'password2': '',
-            },
-        )
+#         response = self.client.post(
+#             reverse('accounts:public_register'),
+#             data={
+#                 'first_name': 'Notify',
+#                 'last_name': 'Admin',
+#                 'username': 'notifyadmin',
+#                 'company': 'Notify Org',
+#                 'email': 'notify-admin@example.com',
+#                 'password1': '',
+#                 'password2': '',
+#             },
+#         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('accounts:waiting'))
-        self.assertGreaterEqual(len(mail.outbox), 2)
-        self.assertIn('admin@example.com', mail.outbox[-1].to)
-        self.assertEqual(mail.outbox[-1].subject, 'New Account Request - Action Required')
+#         self.assertEqual(response.status_code, 302)
+#         self.assertEqual(response.url, reverse('accounts:waiting'))
+#         self.assertGreaterEqual(len(mail.outbox), 2)
+#         self.assertIn('admin@example.com', mail.outbox[-1].to)
+#         self.assertEqual(mail.outbox[-1].subject, 'New Account Request - Action Required')
 
-    @override_settings(
-        EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
-        DEFAULT_FROM_EMAIL='admin@example.com',
-        ADMIN_EMAIL_INBOX='admin@example.com',
-        ASYNC_EMAIL_ENABLED=False,
-    )
-    def test_public_registration_does_not_crash_when_admin_email_already_exists(self):
-        User.objects.create_superuser(
-            username='existingadmin',
-            email='admin@example.com',
-            password='StrongPassword123!',
-        )
+#     @override_settings(
+#         EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+#         DEFAULT_FROM_EMAIL='admin@example.com',
+#         ADMIN_EMAIL_INBOX='admin@example.com',
+#         ASYNC_EMAIL_ENABLED=False,
+#     )
+#     def test_public_registration_does_not_crash_when_admin_email_already_exists(self):
+#         User.objects.create_superuser(
+#             username='existingadmin',
+#             email='admin@example.com',
+#             password='StrongPassword123!',
+#         )
 
-        session = self.client.session
-        session['verified_email'] = 'new-org-admin@example.com'
-        session['google_signup_verified_email'] = 'new-org-admin@example.com'
-        session['registration_verified_new-org-admin@example.com'] = True
-        session.save()
+#         session = self.client.session
+#         session['verified_email'] = 'new-org-admin@example.com'
+#         session['google_signup_verified_email'] = 'new-org-admin@example.com'
+#         session['registration_verified_new-org-admin@example.com'] = True
+#         session.save()
 
-        response = self.client.post(
-            reverse('accounts:public_register'),
-            data={
-                'first_name': 'New',
-                'last_name': 'OrgAdmin',
-                'username': 'neworgadmin',
-                'company': 'Conflict Org',
-                'email': 'new-org-admin@example.com',
-                'password1': '',
-                'password2': '',
-            },
-        )
+#         response = self.client.post(
+#             reverse('accounts:public_register'),
+#             data={
+#                 'first_name': 'New',
+#                 'last_name': 'OrgAdmin',
+#                 'username': 'neworgadmin',
+#                 'company': 'Conflict Org',
+#                 'email': 'new-org-admin@example.com',
+#                 'password1': '',
+#                 'password2': '',
+#             },
+#         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('accounts:waiting'))
-        self.assertTrue(User.objects.filter(username='neworgadmin').exists())
+#         self.assertEqual(response.status_code, 302)
+#         self.assertEqual(response.url, reverse('accounts:waiting'))
+#         self.assertTrue(User.objects.filter(username='neworgadmin').exists())
 
-    def test_public_registration_can_skip_password_after_google_verification(self):
-        session = self.client.session
-        session['verified_email'] = 'google-admin@example.com'
-        session['google_signup_verified_email'] = 'google-admin@example.com'
-        session['registration_verified_google-admin@example.com'] = True
-        session.save()
+#     def test_public_registration_can_skip_password_after_google_verification(self):
+#         session = self.client.session
+#         session['verified_email'] = 'google-admin@example.com'
+#         session['google_signup_verified_email'] = 'google-admin@example.com'
+#         session['registration_verified_google-admin@example.com'] = True
+#         session.save()
 
-        response = self.client.post(
-            reverse('accounts:public_register'),
-            data={
-                'first_name': 'Google',
-                'last_name': 'Admin',
-                'username': 'googleadmin',
-                'company': 'Google Org',
-                'email': 'google-admin@example.com',
-                'password1': '',
-                'password2': '',
-            },
-        )
+#         response = self.client.post(
+#             reverse('accounts:public_register'),
+#             data={
+#                 'first_name': 'Google',
+#                 'last_name': 'Admin',
+#                 'username': 'googleadmin',
+#                 'company': 'Google Org',
+#                 'email': 'google-admin@example.com',
+#                 'password1': '',
+#                 'password2': '',
+#             },
+#         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('accounts:waiting'))
+#         self.assertEqual(response.status_code, 302)
+#         self.assertEqual(response.url, reverse('accounts:waiting'))
 
-        user = User.objects.get(username='googleadmin')
-        self.assertFalse(user.has_usable_password())
+#         user = User.objects.get(username='googleadmin')
+#         self.assertFalse(user.has_usable_password())
 
-    def test_invite_signup_can_skip_password_after_google_verification(self):
-        organization = Organization.objects.create(org_name='Invite Org')
-        sender = User.objects.create_user(
-            username='inviter',
-            email='inviter@example.com',
-            password='StrongPassword123!',
-            organization=organization,
-            is_active=True,
-        )
-        invitation = Invitation.objects.create(
-            sender=sender,
-            organization=organization,
-            recipient_email='invitee@example.com',
-            recipient_role='observer',
-            status='sent',
-        )
+#     def test_invite_signup_can_skip_password_after_google_verification(self):
+#         organization = Organization.objects.create(org_name='Invite Org')
+#         sender = User.objects.create_user(
+#             username='inviter',
+#             email='inviter@example.com',
+#             password='StrongPassword123!',
+#             organization=organization,
+#             is_active=True,
+#         )
+#         invitation = Invitation.objects.create(
+#             sender=sender,
+#             organization=organization,
+#             recipient_email='invitee@example.com',
+#             recipient_role='observer',
+#             status='sent',
+#         )
 
-        session = self.client.session
-        session['google_signup_verified_email'] = 'invitee@example.com'
-        session.save()
+#         session = self.client.session
+#         session['google_signup_verified_email'] = 'invitee@example.com'
+#         session.save()
 
-        response = self.client.post(
-            reverse('accounts:accept_invitation', args=[invitation.token]),
-            data={
-                'first_name': 'Invitee',
-                'last_name': 'User',
-                'username': 'inviteeuser',
-                'password1': '',
-                'password2': '',
-            },
-        )
+#         response = self.client.post(
+#             reverse('accounts:accept_invitation', args=[invitation.token]),
+#             data={
+#                 'first_name': 'Invitee',
+#                 'last_name': 'User',
+#                 'username': 'inviteeuser',
+#                 'password1': '',
+#                 'password2': '',
+#             },
+#         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Account Created!')
+#         self.assertEqual(response.status_code, 200)
+#         self.assertContains(response, 'Account Created!')
 
-        user = User.objects.get(username='inviteeuser')
-        invitation.refresh_from_db()
-        self.assertFalse(user.has_usable_password())
-        self.assertEqual(invitation.status, 'accepted')
+#         user = User.objects.get(username='inviteeuser')
+#         invitation.refresh_from_db()
+#         self.assertFalse(user.has_usable_password())
+#         self.assertEqual(invitation.status, 'accepted')
 
-    @patch('api.views.id_token.verify_oauth2_token')
-    def test_google_oauth_signup_rejects_invite_email_mismatch(self, mock_verify):
-        mock_verify.return_value = {
-            'email': 'different@example.com',
-            'email_verified': True,
-        }
+#     @patch('api.views.id_token.verify_oauth2_token')
+#     def test_google_oauth_signup_rejects_invite_email_mismatch(self, mock_verify):
+#         mock_verify.return_value = {
+#             'email': 'different@example.com',
+#             'email_verified': True,
+#         }
 
-        response = self.client.post(
-            reverse('google_oauth_signup'),
-            data='{"credential": "fake-google-jwt", "purpose": "invite", "expected_email": "invited@example.com"}',
-            content_type='application/json',
-        )
+#         response = self.client.post(
+#             reverse('google_oauth_signup'),
+#             data='{"credential": "fake-google-jwt", "purpose": "invite", "expected_email": "invited@example.com"}',
+#             content_type='application/json',
+#         )
 
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['success'], False)
+#         self.assertEqual(response.status_code, 403)
+#         self.assertEqual(response.json()['success'], False)
 
 
-@override_settings(
-    MICROSOFT_OAUTH_CLIENT_ID='test-microsoft-client-id',
-    MICROSOFT_OAUTH_CLIENT_SECRET='test-microsoft-client-secret',
-    MICROSOFT_OAUTH_TENANT_ID='common',
-    MICROSOFT_OAUTH_REQUIRE_OTP=True,
-    STORAGES={
-        'staticfiles': {
-            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
-        },
-    },
-)
-class MicrosoftOAuthFlowTests(TestCase):
-    def setUp(self):
-        self.org = Organization.objects.create(org_name='Contoso')
-        self.user = User.objects.create_user(
-            username='msuser',
-            email='msuser@example.com',
-            password='StrongPassword123!',
-            organization=self.org,
-            is_active=True,
-        )
+# @override_settings(
+#     MICROSOFT_OAUTH_CLIENT_ID='test-microsoft-client-id',
+#     MICROSOFT_OAUTH_CLIENT_SECRET='test-microsoft-client-secret',
+#     MICROSOFT_OAUTH_TENANT_ID='common',
+#     MICROSOFT_OAUTH_REQUIRE_OTP=True,
+#     STORAGES={
+#         'staticfiles': {
+#             'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+#         },
+#     },
+# )
+# class MicrosoftOAuthFlowTests(TestCase):
+#     def setUp(self):
+#         self.org = Organization.objects.create(org_name='Contoso')
+#         self.user = User.objects.create_user(
+#             username='msuser',
+#             email='msuser@example.com',
+#             password='StrongPassword123!',
+#             organization=self.org,
+#             is_active=True,
+#         )
 
-    def test_microsoft_oauth_start_redirects_to_microsoft_consent_screen(self):
-        response = self.client.get(
-            reverse('microsoft_oauth_start'),
-            {'flow': 'registration', 'next': reverse('accounts:public_register')},
-        )
+#     def test_microsoft_oauth_start_redirects_to_microsoft_consent_screen(self):
+#         response = self.client.get(
+#             reverse('microsoft_oauth_start'),
+#             {'flow': 'registration', 'next': reverse('accounts:public_register')},
+#         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertIn('https://login.microsoftonline.com/common/oauth2/v2.0/authorize', response.url)
-        self.assertIn('client_id=test-microsoft-client-id', response.url)
-        self.assertEqual(self.client.session['microsoft_oauth_flow'], 'registration')
+#         self.assertEqual(response.status_code, 302)
+#         self.assertIn('https://login.microsoftonline.com/common/oauth2/v2.0/authorize', response.url)
+#         self.assertIn('client_id=test-microsoft-client-id', response.url)
+#         self.assertEqual(self.client.session['microsoft_oauth_flow'], 'registration')
 
-    @override_settings(MICROSOFT_OAUTH_REDIRECT_BASE_URL='http://localhost:8000')
-    def test_microsoft_oauth_start_uses_localhost_callback_when_configured(self):
-        response = self.client.get(
-            reverse('microsoft_oauth_start'),
-            {'flow': 'login', 'next': reverse('login')},
-        )
+#     @override_settings(MICROSOFT_OAUTH_REDIRECT_BASE_URL='http://localhost:8000')
+#     def test_microsoft_oauth_start_uses_localhost_callback_when_configured(self):
+#         response = self.client.get(
+#             reverse('microsoft_oauth_start'),
+#             {'flow': 'login', 'next': reverse('login')},
+#         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertIn(
-            'redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fmicrosoft-oauth%2Fcallback%2F',
-            response.url,
-        )
+#         self.assertEqual(response.status_code, 302)
+#         self.assertIn(
+#             'redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fmicrosoft-oauth%2Fcallback%2F',
+#             response.url,
+#         )
 
-    def test_public_register_shows_microsoft_verified_notice_when_microsoft_was_used(self):
-        session = self.client.session
-        session['verified_email'] = 'msuser@example.com'
-        session['google_signup_verified_email'] = 'msuser@example.com'
-        session['registration_verified_msuser@example.com'] = True
-        session['social_signup_provider'] = 'Microsoft'
-        session.save()
+#     def test_public_register_shows_microsoft_verified_notice_when_microsoft_was_used(self):
+#         session = self.client.session
+#         session['verified_email'] = 'msuser@example.com'
+#         session['google_signup_verified_email'] = 'msuser@example.com'
+#         session['registration_verified_msuser@example.com'] = True
+#         session['social_signup_provider'] = 'Microsoft'
+#         session.save()
 
-        response = self.client.get(reverse('accounts:public_register'))
+#         response = self.client.get(reverse('accounts:public_register'))
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Microsoft already verified this email', html=False)
-        self.assertContains(response, 'not required after Microsoft verification', html=False)
+#         self.assertEqual(response.status_code, 200)
+#         self.assertContains(response, 'Microsoft already verified this email', html=False)
+#         self.assertContains(response, 'not required after Microsoft verification', html=False)
 
-    @patch('api.views._exchange_microsoft_code')
-    def test_microsoft_oauth_callback_marks_registration_verified(self, mock_exchange):
-        mock_exchange.return_value = {
-            'preferred_username': 'mscallback@example.com',
-            'given_name': 'Morgan',
-            'family_name': 'Callback',
-        }
+#     @patch('api.views._exchange_microsoft_code')
+#     def test_microsoft_oauth_callback_marks_registration_verified(self, mock_exchange):
+#         mock_exchange.return_value = {
+#             'preferred_username': 'mscallback@example.com',
+#             'given_name': 'Morgan',
+#             'family_name': 'Callback',
+#         }
 
-        session = self.client.session
-        session['microsoft_oauth_state'] = 'ms-state-123'
-        session['microsoft_oauth_flow'] = 'registration'
-        session['microsoft_oauth_next'] = reverse('accounts:public_register')
-        session.save()
+#         session = self.client.session
+#         session['microsoft_oauth_state'] = 'ms-state-123'
+#         session['microsoft_oauth_flow'] = 'registration'
+#         session['microsoft_oauth_next'] = reverse('accounts:public_register')
+#         session.save()
 
-        response = self.client.get(
-            reverse('microsoft_oauth_callback'),
-            {'code': 'sample-code', 'state': 'ms-state-123'},
-        )
+#         response = self.client.get(
+#             reverse('microsoft_oauth_callback'),
+#             {'code': 'sample-code', 'state': 'ms-state-123'},
+#         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('accounts:public_register'))
-        self.assertEqual(self.client.session['verified_email'], 'mscallback@example.com')
-        self.assertTrue(self.client.session['registration_verified_mscallback@example.com'])
+#         self.assertEqual(response.status_code, 302)
+#         self.assertEqual(response.url, reverse('accounts:public_register'))
+#         self.assertEqual(self.client.session['verified_email'], 'mscallback@example.com')
+#         self.assertTrue(self.client.session['registration_verified_mscallback@example.com'])
 
-    @patch('api.views._exchange_microsoft_code')
-    def test_microsoft_oauth_callback_starts_otp_for_existing_active_user(self, mock_exchange):
-        mock_exchange.return_value = {
-            'email': self.user.email,
-            'preferred_username': self.user.email,
-            'given_name': 'Microsoft',
-            'family_name': 'User',
-        }
+#     @patch('api.views._exchange_microsoft_code')
+#     def test_microsoft_oauth_callback_starts_otp_for_existing_active_user(self, mock_exchange):
+#         mock_exchange.return_value = {
+#             'email': self.user.email,
+#             'preferred_username': self.user.email,
+#             'given_name': 'Microsoft',
+#             'family_name': 'User',
+#         }
 
-        session = self.client.session
-        session['microsoft_oauth_state'] = 'ms-login-state'
-        session['microsoft_oauth_flow'] = 'login'
-        session['microsoft_oauth_next'] = reverse('login')
-        session.save()
+#         session = self.client.session
+#         session['microsoft_oauth_state'] = 'ms-login-state'
+#         session['microsoft_oauth_flow'] = 'login'
+#         session['microsoft_oauth_next'] = reverse('login')
+#         session.save()
 
-        response = self.client.get(
-            reverse('microsoft_oauth_callback'),
-            {'code': 'login-code', 'state': 'ms-login-state'},
-        )
+#         response = self.client.get(
+#             reverse('microsoft_oauth_callback'),
+#             {'code': 'login-code', 'state': 'ms-login-state'},
+#         )
 
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('login'))
-        self.assertEqual(self.client.session['pending_user_id'], self.user.id)
-        self.assertTrue(self.client.session['google_login_requires_otp'])
-        self.assertIn('login_otp', self.client.session)
+#         self.assertEqual(response.status_code, 302)
+#         self.assertEqual(response.url, reverse('login'))
+#         self.assertEqual(self.client.session['pending_user_id'], self.user.id)
+#         self.assertTrue(self.client.session['google_login_requires_otp'])
+#         self.assertIn('login_otp', self.client.session)
 
-    def test_login_template_shows_microsoft_button_when_client_id_present(self):
-        response = self.client.get(reverse('login'))
+#     def test_login_template_shows_microsoft_button_when_client_id_present(self):
+#         response = self.client.get(reverse('login'))
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'id="microsoftSignInButton"', html=False)
-        self.assertNotContains(response, 'Set MICROSOFT_OAUTH_CLIENT_ID to enable Microsoft sign-in')
+#         self.assertEqual(response.status_code, 200)
+#         self.assertContains(response, 'id="microsoftSignInButton"', html=False)
+#         self.assertNotContains(response, 'Set MICROSOFT_OAUTH_CLIENT_ID to enable Microsoft sign-in')

--- a/cybersecurity_assessment_tool/api/tests.py
+++ b/cybersecurity_assessment_tool/api/tests.py
@@ -4,7 +4,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.core import mail
 
-from api.models import Organization, User, Report, Risk
+from api.models import Invitation, Organization, User, Report, Risk
 
 class DatabaseEncryptionTests(TestCase):
     def setUp(self):

--- a/cybersecurity_assessment_tool/api/tests.py
+++ b/cybersecurity_assessment_tool/api/tests.py
@@ -1,4 +1,8 @@
-from django.test import TestCase
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
 from api.models import Organization, User, Report, Risk
 
 class DatabaseEncryptionTests(TestCase):
@@ -84,3 +88,51 @@ class DatabaseEncryptionTests(TestCase):
         self.assertEqual(fetched_risk.affected_elements, plaintext_affected)
         self.assertEqual(fetched_risk.recommendations, plaintext_recommendations)
         self.assertEqual(fetched_risk.recommendations["easy_fix"], "Apply the latest security patch.")
+
+
+@override_settings(GOOGLE_OAUTH_CLIENT_ID='test-google-client-id.apps.googleusercontent.com')
+class GoogleOAuthLoginTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(org_name="Acme School")
+        self.user = User.objects.create_user(
+            username="oauthuser",
+            email="oauth@example.com",
+            password="StrongPassword123!",
+            organization=self.org,
+            is_active=True,
+        )
+
+    @patch('api.views.id_token.verify_oauth2_token')
+    def test_google_oauth_logs_in_existing_active_user(self, mock_verify):
+        mock_verify.return_value = {
+            'email': self.user.email,
+            'email_verified': True,
+            'given_name': 'OAuth',
+            'family_name': 'User',
+        }
+
+        response = self.client.post(
+            reverse('google_oauth_login'),
+            data='{"credential": "fake-google-jwt"}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['success'], True)
+        self.assertIn('_auth_user_id', self.client.session)
+
+    @patch('api.views.id_token.verify_oauth2_token')
+    def test_google_oauth_rejects_unknown_user(self, mock_verify):
+        mock_verify.return_value = {
+            'email': 'missing@example.com',
+            'email_verified': True,
+        }
+
+        response = self.client.post(
+            reverse('google_oauth_login'),
+            data='{"credential": "fake-google-jwt"}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['success'], False)

--- a/cybersecurity_assessment_tool/api/tests.py
+++ b/cybersecurity_assessment_tool/api/tests.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.core import mail
 
 from api.models import Organization, User, Report, Risk
 

--- a/cybersecurity_assessment_tool/api/tests.py
+++ b/cybersecurity_assessment_tool/api/tests.py
@@ -136,3 +136,321 @@ class GoogleOAuthLoginTests(TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['success'], False)
+
+
+@override_settings(
+    GOOGLE_OAUTH_CLIENT_ID='test-google-client-id.apps.googleusercontent.com',
+    STORAGES={
+        'staticfiles': {
+            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+        },
+    },
+)
+class GoogleOAuthSignupTests(TestCase):
+    @patch('api.views.id_token.verify_oauth2_token')
+    def test_google_oauth_signup_marks_registration_email_verified(self, mock_verify):
+        mock_verify.return_value = {
+            'email': 'newsignup@example.com',
+            'email_verified': True,
+            'given_name': 'New',
+            'family_name': 'User',
+        }
+
+        response = self.client.post(
+            reverse('google_oauth_signup'),
+            data='{"credential": "fake-google-jwt", "purpose": "registration"}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['success'], True)
+        self.assertEqual(response.json()['email'], 'newsignup@example.com')
+        self.assertEqual(response.json()['first_name'], 'New')
+        self.assertEqual(self.client.session['verified_email'], 'newsignup@example.com')
+        self.assertTrue(self.client.session['registration_verified_newsignup@example.com'])
+
+    def test_public_registration_prefills_google_verified_email_on_get(self):
+        session = self.client.session
+        session['verified_email'] = 'prefill@example.com'
+        session['google_signup_verified_email'] = 'prefill@example.com'
+        session['registration_verified_prefill@example.com'] = True
+        session['google_signup_prefill'] = {
+            'email': 'prefill@example.com',
+            'first_name': 'Prefilled',
+            'last_name': 'User',
+        }
+        session.save()
+
+        response = self.client.get(reverse('accounts:public_register'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="prefill@example.com"', html=False)
+        self.assertContains(response, 'password and OTP step can be skipped', html=False)
+
+    @override_settings(
+        EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+        DEFAULT_FROM_EMAIL='noreply@example.com',
+        ADMIN_EMAIL_INBOX='admin@example.com',
+        ASYNC_EMAIL_ENABLED=False,
+    )
+    def test_public_registration_sends_admin_notification_email(self):
+        session = self.client.session
+        session['verified_email'] = 'notify-admin@example.com'
+        session['google_signup_verified_email'] = 'notify-admin@example.com'
+        session['registration_verified_notify-admin@example.com'] = True
+        session.save()
+
+        response = self.client.post(
+            reverse('accounts:public_register'),
+            data={
+                'first_name': 'Notify',
+                'last_name': 'Admin',
+                'username': 'notifyadmin',
+                'company': 'Notify Org',
+                'email': 'notify-admin@example.com',
+                'password1': '',
+                'password2': '',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('accounts:waiting'))
+        self.assertGreaterEqual(len(mail.outbox), 2)
+        self.assertIn('admin@example.com', mail.outbox[-1].to)
+        self.assertEqual(mail.outbox[-1].subject, 'New Account Request - Action Required')
+
+    @override_settings(
+        EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+        DEFAULT_FROM_EMAIL='admin@example.com',
+        ADMIN_EMAIL_INBOX='admin@example.com',
+        ASYNC_EMAIL_ENABLED=False,
+    )
+    def test_public_registration_does_not_crash_when_admin_email_already_exists(self):
+        User.objects.create_superuser(
+            username='existingadmin',
+            email='admin@example.com',
+            password='StrongPassword123!',
+        )
+
+        session = self.client.session
+        session['verified_email'] = 'new-org-admin@example.com'
+        session['google_signup_verified_email'] = 'new-org-admin@example.com'
+        session['registration_verified_new-org-admin@example.com'] = True
+        session.save()
+
+        response = self.client.post(
+            reverse('accounts:public_register'),
+            data={
+                'first_name': 'New',
+                'last_name': 'OrgAdmin',
+                'username': 'neworgadmin',
+                'company': 'Conflict Org',
+                'email': 'new-org-admin@example.com',
+                'password1': '',
+                'password2': '',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('accounts:waiting'))
+        self.assertTrue(User.objects.filter(username='neworgadmin').exists())
+
+    def test_public_registration_can_skip_password_after_google_verification(self):
+        session = self.client.session
+        session['verified_email'] = 'google-admin@example.com'
+        session['google_signup_verified_email'] = 'google-admin@example.com'
+        session['registration_verified_google-admin@example.com'] = True
+        session.save()
+
+        response = self.client.post(
+            reverse('accounts:public_register'),
+            data={
+                'first_name': 'Google',
+                'last_name': 'Admin',
+                'username': 'googleadmin',
+                'company': 'Google Org',
+                'email': 'google-admin@example.com',
+                'password1': '',
+                'password2': '',
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('accounts:waiting'))
+
+        user = User.objects.get(username='googleadmin')
+        self.assertFalse(user.has_usable_password())
+
+    def test_invite_signup_can_skip_password_after_google_verification(self):
+        organization = Organization.objects.create(org_name='Invite Org')
+        sender = User.objects.create_user(
+            username='inviter',
+            email='inviter@example.com',
+            password='StrongPassword123!',
+            organization=organization,
+            is_active=True,
+        )
+        invitation = Invitation.objects.create(
+            sender=sender,
+            organization=organization,
+            recipient_email='invitee@example.com',
+            recipient_role='observer',
+            status='sent',
+        )
+
+        session = self.client.session
+        session['google_signup_verified_email'] = 'invitee@example.com'
+        session.save()
+
+        response = self.client.post(
+            reverse('accounts:accept_invitation', args=[invitation.token]),
+            data={
+                'first_name': 'Invitee',
+                'last_name': 'User',
+                'username': 'inviteeuser',
+                'password1': '',
+                'password2': '',
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Account Created!')
+
+        user = User.objects.get(username='inviteeuser')
+        invitation.refresh_from_db()
+        self.assertFalse(user.has_usable_password())
+        self.assertEqual(invitation.status, 'accepted')
+
+    @patch('api.views.id_token.verify_oauth2_token')
+    def test_google_oauth_signup_rejects_invite_email_mismatch(self, mock_verify):
+        mock_verify.return_value = {
+            'email': 'different@example.com',
+            'email_verified': True,
+        }
+
+        response = self.client.post(
+            reverse('google_oauth_signup'),
+            data='{"credential": "fake-google-jwt", "purpose": "invite", "expected_email": "invited@example.com"}',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['success'], False)
+
+
+@override_settings(
+    MICROSOFT_OAUTH_CLIENT_ID='test-microsoft-client-id',
+    MICROSOFT_OAUTH_CLIENT_SECRET='test-microsoft-client-secret',
+    MICROSOFT_OAUTH_TENANT_ID='common',
+    MICROSOFT_OAUTH_REQUIRE_OTP=True,
+    STORAGES={
+        'staticfiles': {
+            'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+        },
+    },
+)
+class MicrosoftOAuthFlowTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(org_name='Contoso')
+        self.user = User.objects.create_user(
+            username='msuser',
+            email='msuser@example.com',
+            password='StrongPassword123!',
+            organization=self.org,
+            is_active=True,
+        )
+
+    def test_microsoft_oauth_start_redirects_to_microsoft_consent_screen(self):
+        response = self.client.get(
+            reverse('microsoft_oauth_start'),
+            {'flow': 'registration', 'next': reverse('accounts:public_register')},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('https://login.microsoftonline.com/common/oauth2/v2.0/authorize', response.url)
+        self.assertIn('client_id=test-microsoft-client-id', response.url)
+        self.assertEqual(self.client.session['microsoft_oauth_flow'], 'registration')
+
+    @override_settings(MICROSOFT_OAUTH_REDIRECT_BASE_URL='http://localhost:8000')
+    def test_microsoft_oauth_start_uses_localhost_callback_when_configured(self):
+        response = self.client.get(
+            reverse('microsoft_oauth_start'),
+            {'flow': 'login', 'next': reverse('login')},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(
+            'redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fmicrosoft-oauth%2Fcallback%2F',
+            response.url,
+        )
+
+    def test_public_register_shows_microsoft_verified_notice_when_microsoft_was_used(self):
+        session = self.client.session
+        session['verified_email'] = 'msuser@example.com'
+        session['google_signup_verified_email'] = 'msuser@example.com'
+        session['registration_verified_msuser@example.com'] = True
+        session['social_signup_provider'] = 'Microsoft'
+        session.save()
+
+        response = self.client.get(reverse('accounts:public_register'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Microsoft already verified this email', html=False)
+        self.assertContains(response, 'not required after Microsoft verification', html=False)
+
+    @patch('api.views._exchange_microsoft_code')
+    def test_microsoft_oauth_callback_marks_registration_verified(self, mock_exchange):
+        mock_exchange.return_value = {
+            'preferred_username': 'mscallback@example.com',
+            'given_name': 'Morgan',
+            'family_name': 'Callback',
+        }
+
+        session = self.client.session
+        session['microsoft_oauth_state'] = 'ms-state-123'
+        session['microsoft_oauth_flow'] = 'registration'
+        session['microsoft_oauth_next'] = reverse('accounts:public_register')
+        session.save()
+
+        response = self.client.get(
+            reverse('microsoft_oauth_callback'),
+            {'code': 'sample-code', 'state': 'ms-state-123'},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('accounts:public_register'))
+        self.assertEqual(self.client.session['verified_email'], 'mscallback@example.com')
+        self.assertTrue(self.client.session['registration_verified_mscallback@example.com'])
+
+    @patch('api.views._exchange_microsoft_code')
+    def test_microsoft_oauth_callback_starts_otp_for_existing_active_user(self, mock_exchange):
+        mock_exchange.return_value = {
+            'email': self.user.email,
+            'preferred_username': self.user.email,
+            'given_name': 'Microsoft',
+            'family_name': 'User',
+        }
+
+        session = self.client.session
+        session['microsoft_oauth_state'] = 'ms-login-state'
+        session['microsoft_oauth_flow'] = 'login'
+        session['microsoft_oauth_next'] = reverse('login')
+        session.save()
+
+        response = self.client.get(
+            reverse('microsoft_oauth_callback'),
+            {'code': 'login-code', 'state': 'ms-login-state'},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('login'))
+        self.assertEqual(self.client.session['pending_user_id'], self.user.id)
+        self.assertTrue(self.client.session['google_login_requires_otp'])
+        self.assertIn('login_otp', self.client.session)
+
+    def test_login_template_shows_microsoft_button_when_client_id_present(self):
+        response = self.client.get(reverse('login'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="microsoftSignInButton"', html=False)
+        self.assertNotContains(response, 'Set MICROSOFT_OAUTH_CLIENT_ID to enable Microsoft sign-in')

--- a/cybersecurity_assessment_tool/api/urls.py
+++ b/cybersecurity_assessment_tool/api/urls.py
@@ -24,7 +24,8 @@ urlpatterns = [
     # path('public-signup/', views.public_registration, name='public_registration'),
 
     # Login URLs
-    path('login/', views.login_view, name='login'),
+    # path('login/', views.login_view, name='login'),
+    path('google-oauth-login/', views.google_oauth_login, name='google_oauth_login'),
     path('verify-login-otp/', views.verify_login_otp, name='verify_login_otp'),
     path('login-redirect/', views.questionnaire_redirect, name='login_redirect'),
 

--- a/cybersecurity_assessment_tool/api/utils/email_factory.py
+++ b/cybersecurity_assessment_tool/api/utils/email_factory.py
@@ -70,6 +70,20 @@ def send_email_by_type(email_type, recipient=None, context_overrides=None):
                 "invite_link": "http://localhost:8000/invite/abc123xyz/"
             }
         },
+
+        # Email to the org admin when an invited user finishes creating their account
+        "invite_accepted": {
+            "subject": "Team Member Joined Your Organization",
+            "template": "emails/invite_accepted.html",
+            "context": {
+                "admin_name": "Org Admin",
+                "member_name": "New Team Member",
+                "member_email": "member@example.com",
+                "company": "RePortly",
+                "role": "Observer",
+                "login_url": "http://localhost:8000/accounts/login/",
+            }
+        },
         
         # Report ready email sent to user when their security report is generated
         "report": {

--- a/cybersecurity_assessment_tool/api/views.py
+++ b/cybersecurity_assessment_tool/api/views.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from accounts.forms import InvitationSignupForm, PublicRegistrationForm
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated, AllowAny
-from .models import Invitation, Organization, User, Report, Risk
+from .models import Invitation, Organization, User, Report, Risk, generate_email_hash
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token
 from .serializers import OrganizationSerializer, UserSerializer, ReportSerializer, RiskSerializer

--- a/cybersecurity_assessment_tool/api/views.py
+++ b/cybersecurity_assessment_tool/api/views.py
@@ -9,7 +9,9 @@ from django.utils import timezone
 from accounts.forms import InvitationSignupForm, PublicRegistrationForm
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated, AllowAny
-from .models import Invitation, Organization, User, Report, Risk, generate_email_hash
+from .models import Invitation, Organization, User, Report, Risk
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
 from .serializers import OrganizationSerializer, UserSerializer, ReportSerializer, RiskSerializer
 from django.contrib.auth import get_user_model
 from django.contrib.admin.views.decorators import staff_member_required
@@ -22,8 +24,10 @@ from django.contrib.auth import authenticate, login
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.decorators import login_required
 import secrets
-from django.conf import settings
-from django.template.loader import render_to_string
+import os
+
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 
 User = get_user_model()
 
@@ -317,6 +321,94 @@ def reject_registration(request, user_id):
     
     return redirect('admin:api_user_changelist')
 
+def _get_login_context(form=None):
+    """Shared context for rendering the login page."""
+    google_client_id = getattr(settings, 'GOOGLE_OAUTH_CLIENT_ID', '').strip()
+    return {
+        'form': form or AuthenticationForm(),
+        'google_oauth_enabled': bool(google_client_id),
+        'google_oauth_client_id': google_client_id,
+    }
+
+
+@require_POST
+def google_oauth_login(request):
+    """Log in an existing approved user with Google OAuth."""
+    client_id = getattr(settings, 'GOOGLE_OAUTH_CLIENT_ID', '').strip()
+    is_test_request = getattr(settings, 'TESTING', False) or 'test' in sys.argv
+    if not client_id and not is_test_request:
+        return JsonResponse({
+            'success': False,
+            'error': 'Google OAuth is not configured for this environment.',
+        }, status=503)
+
+    try:
+        data = json.loads(request.body) if request.body else request.POST
+    except json.JSONDecodeError:
+        return JsonResponse({
+            'success': False,
+            'error': 'Invalid login payload.',
+        }, status=400)
+
+    credential = (data.get('credential') or data.get('id_token') or '').strip()
+    if not credential:
+        return JsonResponse({
+            'success': False,
+            'error': 'Missing Google credential.',
+        }, status=400)
+
+    try:
+        token_payload = id_token.verify_oauth2_token(
+            credential,
+            google_requests.Request(),
+            client_id or None,
+        )
+    except ValueError:
+        return JsonResponse({
+            'success': False,
+            'error': 'Google sign-in could not be verified.',
+        }, status=400)
+
+    email = (token_payload.get('email') or '').strip().lower()
+    if not email or not token_payload.get('email_verified'):
+        return JsonResponse({
+            'success': False,
+            'error': 'Your Google email address is not verified.',
+        }, status=403)
+
+    user = User.objects.filter(email_hash=generate_email_hash(email)).first()
+    if user is None:
+        return JsonResponse({
+            'success': False,
+            'error': 'No approved account is linked to this Google email address.',
+        }, status=403)
+
+    if not user.is_active:
+        return JsonResponse({
+            'success': False,
+            'error': 'Your account is pending approval. Please contact your administrator.',
+        }, status=403)
+
+    updated = False
+    if token_payload.get('given_name') and not user.first_name:
+        user.first_name = token_payload['given_name']
+        updated = True
+    if token_payload.get('family_name') and not user.last_name:
+        user.last_name = token_payload['family_name']
+        updated = True
+    if updated:
+        user.save()
+
+    user.backend = 'django.contrib.auth.backends.ModelBackend'
+    login(request, user)
+
+    return JsonResponse({
+        'success': True,
+        'redirect_url': reverse('login_redirect'),
+        'message': 'Signed in with Google successfully.',
+    })
+
+
 def login_view(request):
     """Custom login view that handles OTP verification"""
     if request.method == 'POST':
@@ -381,11 +473,11 @@ def login_view(request):
                     from django.contrib.auth import login
                     login(request, user)
                     return redirect('dashboard')
-            return render(request, 'registration/login.html', {'form': form})
+            return render(request, 'registration/login.html', _get_login_context(form))
     
     # GET request - show login form
     form = AuthenticationForm()
-    return render(request, 'registration/login.html', {'form': form})
+    return render(request, 'registration/login.html', _get_login_context(form))
 
 @require_POST
 def verify_login_otp(request):

--- a/cybersecurity_assessment_tool/api/views.py
+++ b/cybersecurity_assessment_tool/api/views.py
@@ -1,3 +1,4 @@
+import sys
 from urllib import request
 import uuid
 from django.shortcuts import render, redirect

--- a/cybersecurity_assessment_tool/api/views.py
+++ b/cybersecurity_assessment_tool/api/views.py
@@ -26,9 +26,6 @@ from django.contrib.auth.decorators import login_required
 import secrets
 import os
 
-EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
-
 User = get_user_model()
 
 ## Simple session-based OTP storage (use Redis/Cache in production)

--- a/cybersecurity_assessment_tool/config/settings.py
+++ b/cybersecurity_assessment_tool/config/settings.py
@@ -248,6 +248,9 @@ INTERNAL_IPS = [
 LOGIN_REDIRECT_URL = 'login_redirect'
 LOGOUT_REDIRECT_URL = "home"
 
+GOOGLE_OAUTH_CLIENT_ID = os.environ.get('GOOGLE_OAUTH_CLIENT_ID', '').strip()
+GOOGLE_OAUTH_ENABLED = bool(GOOGLE_OAUTH_CLIENT_ID)
+
 # ---------------------------------------------------------------------------
 # Email Configuration
 # ---------------------------------------------------------------------------
@@ -269,7 +272,7 @@ if EMAIL_BACKEND_TYPE == 'sendgrid' or IS_HEROKU:
 elif EMAIL_BACKEND_TYPE == 'smtp':
     # Use Gmail or other SMTP
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.gmail.com') # Defaults to Gmail SMTP, but should be updated to sendgrid in the future
+    EMAIL_HOST = os.environ.get('EMAIL_HOST', 'smtp.sendgrid.net') # Defaults to SendGrid SMTP
     EMAIL_PORT = int(os.environ.get('EMAIL_PORT', 587))
     EMAIL_USE_TLS = True
     EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')

--- a/cybersecurity_assessment_tool/templates/emails/invite_accepted.html
+++ b/cybersecurity_assessment_tool/templates/emails/invite_accepted.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Team Member Joined</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 20px;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 30px;
+            background: white;
+            border-radius: 10px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        .header {
+            background: linear-gradient(135deg, #198754, #157347);
+            color: white;
+            padding: 25px;
+            text-align: center;
+            border-radius: 8px 8px 0 0;
+            margin: -30px -30px 20px -30px;
+        }
+        .info-card {
+            background: #f8f9fa;
+            padding: 22px;
+            border-radius: 10px;
+            margin: 20px 0;
+        }
+        .info-card p {
+            margin: 10px 0;
+        }
+        .button {
+            background: #0d6efd;
+            color: white !important;
+            padding: 14px 28px;
+            text-decoration: none;
+            border-radius: 6px;
+            display: inline-block;
+            font-weight: bold;
+            margin-top: 10px;
+        }
+        .footer {
+            margin-top: 30px;
+            font-size: 13px;
+            color: #6c757d;
+            text-align: center;
+            border-top: 1px solid #dee2e6;
+            padding-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 style="margin: 0;">✅ Team Member Joined</h1>
+            <p style="margin: 6px 0 0 0; opacity: 0.9;">An invited user has created their account</p>
+        </div>
+
+        <p>Hello {{ admin_name }},</p>
+        <p><strong>{{ member_name }}</strong> has accepted the invitation and created an account for <strong>{{ company }}</strong>.</p>
+
+        <div class="info-card">
+            <p><strong>Name:</strong> {{ member_name }}</p>
+            <p><strong>Email:</strong> <a href="mailto:{{ member_email }}">{{ member_email }}</a></p>
+            <p><strong>Role:</strong> {{ role }}</p>
+            <p><strong>Organization:</strong> {{ company }}</p>
+        </div>
+
+        <p style="text-align: center;">
+            <a href="{{ login_url }}" class="button">Open Dashboard</a>
+        </p>
+
+        <div class="footer">
+            <p>If you have questions, contact {{ contact_email }}.<br>Cybersecurity Assessment Tool</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/cybersecurity_assessment_tool/templates/registration/login.html
+++ b/cybersecurity_assessment_tool/templates/registration/login.html
@@ -178,6 +178,22 @@
         background-color: #f9fafb;
     }
 
+    .oauth-google-slot {
+        width: 100%;
+        min-height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .oauth-disabled-note {
+        font-size: 0.75rem;
+        color: #6b7280;
+        text-align: center;
+        margin-top: -0.75rem;
+        margin-bottom: 1rem;
+    }
+
     .auth-footer {
         text-align: center;
         font-size: 0.875rem;
@@ -247,6 +263,7 @@
             </button>
         </form>
 
+
         <!-- <div class="auth-divider">
             <span class="divider-text">Or continue with</span>
         </div>
@@ -254,8 +271,19 @@
         <div class="social-login">
             <button class="social-button" disabled>Google</button>
             <button class="social-button" disabled>Apple</button>
-        </div> -->
+        </div>
 
+        {% if google_oauth_enabled %}
+                <div id="googleSignInButton" class="oauth-google-slot"></div>
+            {% else %}
+                <button class="social-button" disabled title="Set GOOGLE_OAUTH_CLIENT_ID to enable Google sign-in">Google</button>
+            {% endif %}
+            <button class="social-button" disabled title="Coming soon">Apple</button>
+        </div>
+
+        {% if not google_oauth_enabled %}
+            <p class="oauth-disabled-note">Google sign-in will appear automatically once OAuth is configured.</p>
+        {% endif %}
         <div class="auth-footer">
             <p>New to our platform? <a href="{% url 'accounts:public_register' %}" class="signup-link">Create an account</a></p>
         </div>
@@ -272,6 +300,9 @@
 {% block extra_js %}
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% if google_oauth_enabled %}
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+{% endif %}
 
 <script>
 // CSRF token setup
@@ -298,7 +329,53 @@ $.ajaxSetup({
     }
 });
 
+function handleGoogleSignIn(response) {
+    if (!response || !response.credential) {
+        $('#loginError').text('Google sign-in was cancelled. Please try again.').show();
+        return;
+    }
+
+    $('#loginError').hide();
+
+    $.ajax({
+        url: '{% url "google_oauth_login" %}',
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({ credential: response.credential }),
+        success: function(res) {
+            window.location.href = res.redirect_url || '/dashboard/';
+        },
+        error: function(xhr) {
+            const message = xhr.responseJSON?.error || 'Google sign-in failed. Please try again.';
+            $('#loginError').text(message).show();
+        }
+    });
+}
+
+function initializeGoogleLogin() {
+    const buttonContainer = document.getElementById('googleSignInButton');
+    if (!buttonContainer || !window.google || !google.accounts || !google.accounts.id) {
+        return;
+    }
+
+    google.accounts.id.initialize({
+        client_id: '{{ google_oauth_client_id|escapejs }}',
+        callback: handleGoogleSignIn,
+        auto_select: false,
+        cancel_on_tap_outside: true
+    });
+
+    google.accounts.id.renderButton(buttonContainer, {
+        theme: 'outline',
+        size: 'large',
+        text: 'continue_with',
+        shape: 'rectangular',
+        width: Math.max(buttonContainer.offsetWidth, 180)
+    });
+}
+
 $(document).ready(function() {
+    initializeGoogleLogin();
 
     $('#loginForm').submit(function(e) {
         e.preventDefault();

--- a/cybersecurity_assessment_tool/templates/registration/login.html
+++ b/cybersecurity_assessment_tool/templates/registration/login.html
@@ -152,8 +152,10 @@
     }
 
     .social-login {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
         gap: 0.75rem;
         margin-bottom: 1.5rem;
     }
@@ -263,27 +265,39 @@
             </button>
         </form>
 
-
-        <!-- <div class="auth-divider">
+        <!-- Cleaned up social login section -->
+        <div class="auth-divider">
             <span class="divider-text">Or continue with</span>
         </div>
 
+        <!-- Cleaned up social login section -->
         <div class="social-login">
-            <button class="social-button" disabled>Google</button>
-            <button class="social-button" disabled>Apple</button>
-        </div>
-
-        {% if google_oauth_enabled %}
-                <div id="googleSignInButton" class="oauth-google-slot"></div>
+            {% if google_oauth_enabled %}
+                <!-- Google's Native HTML API handles the race conditions automatically! -->
+                <div id="g_id_onload"
+                     data-client_id="{{ google_oauth_client_id }}"
+                     data-callback="handleGoogleSignIn"
+                     data-auto_select="false">
+                </div>
+                <div class="g_id_signin"
+                     data-type="standard"
+                     data-shape="rectangular"
+                     data-theme="outline"
+                     data-text="signin_with"
+                     data-size="large"
+                     data-logo_alignment="left">
+                </div>
             {% else %}
                 <button class="social-button" disabled title="Set GOOGLE_OAUTH_CLIENT_ID to enable Google sign-in">Google</button>
             {% endif %}
-            <button class="social-button" disabled title="Coming soon">Apple</button>
+            
+            <!-- <button class="social-button" disabled title="Coming soon">Apple</button> -->
         </div>
 
         {% if not google_oauth_enabled %}
-            <p class="oauth-disabled-note">Google sign-in will appear automatically once OAuth is configured.</p>
+            <p class="oauth-disabled-note" style="font-size: 0.75rem; text-align: center; color: #6b7280; margin-bottom: 1rem;">Google sign-in will appear automatically once OAuth is configured.</p>
         {% endif %}
+        
         <div class="auth-footer">
             <p>New to our platform? <a href="{% url 'accounts:public_register' %}" class="signup-link">Create an account</a></p>
         </div>
@@ -300,7 +314,9 @@
 {% block extra_js %}
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
 {% if google_oauth_enabled %}
+<!-- Load Google script with async defer - no ?onload needed since we use HTML API -->
 <script src="https://accounts.google.com/gsi/client" async defer></script>
 {% endif %}
 
@@ -329,6 +345,7 @@ $.ajaxSetup({
     }
 });
 
+// This function is called automatically by Google's script via data-callback
 function handleGoogleSignIn(response) {
     if (!response || !response.credential) {
         $('#loginError').text('Google sign-in was cancelled. Please try again.').show();
@@ -352,30 +369,7 @@ function handleGoogleSignIn(response) {
     });
 }
 
-function initializeGoogleLogin() {
-    const buttonContainer = document.getElementById('googleSignInButton');
-    if (!buttonContainer || !window.google || !google.accounts || !google.accounts.id) {
-        return;
-    }
-
-    google.accounts.id.initialize({
-        client_id: '{{ google_oauth_client_id|escapejs }}',
-        callback: handleGoogleSignIn,
-        auto_select: false,
-        cancel_on_tap_outside: true
-    });
-
-    google.accounts.id.renderButton(buttonContainer, {
-        theme: 'outline',
-        size: 'large',
-        text: 'continue_with',
-        shape: 'rectangular',
-        width: Math.max(buttonContainer.offsetWidth, 180)
-    });
-}
-
 $(document).ready(function() {
-    initializeGoogleLogin();
 
     $('#loginForm').submit(function(e) {
         e.preventDefault();
@@ -404,7 +398,6 @@ $(document).ready(function() {
                                 data: JSON.stringify({ otp_input: otpCode }),
                                 success: function(res) {
                                     done(); // signal success to the modal
-                                    // store redirect for onSuccess below
                                     window._otpRedirectUrl = res.redirect_url;
                                 },
                                 error: function(xhr) {
@@ -453,5 +446,3 @@ $(document).ready(function() {
 });
 </script>
 {% endblock %}
-
-<!-- http://127.0.0.1:8000/accounts/login/ -->


### PR DESCRIPTION
- Google OAuth (for Login only since it creates and logs in to the acc with OAuth) that Onella implemented. Hiding Apple for now.
- Email is sent to the Org Admin that the person who was invited created an account.